### PR TITLE
Quick Applescript Fixes

### DIFF
--- a/applescript/by-noah-britton/README.md
+++ b/applescript/by-noah-britton/README.md
@@ -21,17 +21,17 @@ Note that the notifications can't quite keep up with the time, and any queued no
 
 ```bash
 cat 2222.txt | while read line; do
-  osascript -e "display notification \"2222\" with title \"$line\""; fi
+  osascript -e "display notification \"2222\" with title \"$line\"";
   sleep 0.6039604;
 done
 ```
 
 #### AppleScript alerts 🚨
-Note that to stop this one, you've gotta close one of the popups and then quickly hit `control-c`
+Note that to stop this one, you've gotta tab over, then hit `control-c`
 
 ```bash
 cat 2222.txt | while read line; do
-  osascript -e "display alert \"$line\""; fi
+  osascript -e "display alert \"$line\"";
   sleep 0.6039604;
 done
 ```

--- a/applescript/by-noah-britton/README.md
+++ b/applescript/by-noah-britton/README.md
@@ -27,7 +27,7 @@ done
 ```
 
 #### AppleScript alerts 🚨
-Note that to stop this one, you've gotta tab over, then hit `control-c`
+Note that to stop this one, you've gotta tab back to the terminal, then hit `control-c`
 
 ```bash
 cat 2222.txt | while read line; do


### PR DESCRIPTION
Two small corrections:
1. `fi`'s at the end of each call to `osascript` are no longer necessary
2. The Alert's can be ignored rather than closed, and you can tab back over to the terminal and `ctrl-c` (or, this could be ignored in favor of the fun of rushing to stop script) 
